### PR TITLE
Annc fixes

### DIFF
--- a/src/backend/api/announcements.js
+++ b/src/backend/api/announcements.js
@@ -11,7 +11,7 @@ function encodeHTML(s) {
 
 // get all announcements, with optional LIMIT and OFFSET
 router.get('/', (req, res) => {
-  var query = `SELECT * FROM announcements`
+  var query = `SELECT * FROM announcements ORDER BY id DESC`
   //if(req.query.limit !== "undefined")
   //{
   //  query = query + ' LIMIT ' + req.query.limit

--- a/src/frontend/StaticPages/Announcements.html
+++ b/src/frontend/StaticPages/Announcements.html
@@ -117,7 +117,7 @@
                                 for="announcement">
                                 Announcement
                             </label>
-                            <textarea class="form-control" placeholder="" rows=5 id="announcement">Enter an announcement here.</textarea>
+                            <textarea class="form-control" placeholder="Enter an announcement here." rows=5 id="announcement"></textarea>
                         </div>
                     </div>
                     <div class="card-footer">
@@ -152,7 +152,7 @@
                                 for="edit-announcement">
                                 New Announcement
                             </label>
-                            <textarea class="form-control" placeholder="" rows=5 id="edit-announcement"></textarea>
+                            <textarea class="form-control" placeholder="Enter the new announcement here." rows=5 id="edit-announcement"></textarea>
                         </div>
                     </div>
                     <div class="card-footer">

--- a/src/frontend/StaticPages/Announcements.html
+++ b/src/frontend/StaticPages/Announcements.html
@@ -251,12 +251,15 @@
         }
         // delete an announcement that is displayed on the page
         function removeAnnouncement(ctl) {
-
-            // DELETE ANNOUNCEMENT FROM DATABASE HERE
-            deleteAnnouncement(ctl);
-            getAnnouncements("announcements");
-            // delete the announcement from announcement table
-            $(ctl).parents("tr").remove();
+            // get user confirmation before deleting
+            const conf = confirm("Delete the announcement?");
+            if (conf) {
+                // DELETE ANNOUNCEMENT FROM DATABASE HERE
+                deleteAnnouncement(ctl);
+                getAnnouncements("announcements");
+                // delete the announcement from announcement table
+                $(ctl).parents("tr").remove();
+            }
         }
     </script>
 


### PR DESCRIPTION
This is a very simple series of 3 commits. 

- The first commit adds a confirmation message when deleting an announcement. 
- The second commit fixes the placeholders for textareas on the announcements page.
- Finally, the third commit adds `ORDER BY id DESC` to the get announcements query, so the announcements are now displayed in reverse chronological order.